### PR TITLE
Make the SPM package dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "FoundationExtensions",
     platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
     products: [
-        .library(name: "FoundationExtensions", targets: ["FoundationExtensions"])
+        .library(name: "FoundationExtensions", type: .dynamic, targets: ["FoundationExtensions"])
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
Xcode should be able to detect diamond dependency and automatically switch to dynamic, when type is not specified in the product. However, it always links statically unless explicitly set as dynamic in the package manifest.

https://forums.swift.org/t/how-to-link-a-swift-package-as-dynamic/32062

https://forums.developer.apple.com/thread/128806

Until it's solved, we must set to dynamic or create a shim package internally that proxies the linking.

https://github.com/renaudjenny/Swift-Package-Manager-Static-Dynamic-Xcode-Bug