### PR TITLE
Add AnyEncodable Helper + Tests

### DIFF
--- a/Sources/FoundationExtensions/Codable/AnyEncodable.swift
+++ b/Sources/FoundationExtensions/Codable/AnyEncodable.swift
@@ -22,3 +22,12 @@ public struct AnyEncodable: Encodable {
         try encodeFunc(encoder)
     }
 }
+
+// MARK: - Encodable x AnyEncodable
+extension Encodable {
+    /// Creates an AnyEncodable out of the receiver.
+    /// - Returns: AnyEncodable that contains the encoding function of the receiver.
+    public var anyEncodable: AnyEncodable {
+        return AnyEncodable(self)
+    }
+}

--- a/Tests/FoundationExtensionsTests/Codable/AnyEncodableTests.swift
+++ b/Tests/FoundationExtensionsTests/Codable/AnyEncodableTests.swift
@@ -1,0 +1,66 @@
+//
+//  AnyEncodableTests.swift
+//  
+//
+//  Created by Luis Reisewitz on 04.06.20.
+//
+
+#if !os(watchOS)
+import FoundationExtensions
+import XCTest
+
+class AnyEncodableTests: XCTestCase {
+    let encoder = JSONEncoder()
+
+    // MARK: - String Encoding
+    func testStringEncodingInit() {
+        // Given
+        let testString = "This is a test string to test encoding. \\::: ☝️"
+
+        // When
+        let sut = AnyEncodable(testString)
+
+        // Then
+        XCTAssertEqual(try? encoder.encode(testString), try? encoder.encode(sut))
+    }
+    func testStringEncodingHelper() {
+        // Given
+        let testString = "This is a test string to test encoding. \\::: ☝️"
+
+        // When
+        let sut = testString.anyEncodable
+
+        // Then
+        XCTAssertEqual(try? encoder.encode(testString), try? encoder.encode(sut))
+    }
+
+    // MARK: - Dictionary Encoding
+    func testDictionaryEncodingInit() {
+        // Given
+        let testDictionary: [String: [Int]] = [
+            "key1": [1, 5, 10],
+            "key2": [5, 292, 2828]
+        ]
+
+        // When
+        let sut = AnyEncodable(testDictionary)
+
+        // Then
+        XCTAssertEqual(try? encoder.encode(testDictionary), try? encoder.encode(sut))
+    }
+    func testDictionaryEncodingHelper() {
+        // Given
+        let testDictionary: [String: [Int]] = [
+            "key1": [1, 5, 10],
+            "key2": [5, 292, 2828]
+        ]
+
+        // When
+        let sut = testDictionary.anyEncodable
+
+        // Then
+        XCTAssertEqual(try? encoder.encode(testDictionary), try? encoder.encode(sut))
+    }
+}
+
+#endif


### PR DESCRIPTION
I renamed the function and made it a property, as `typeErased()` is not clear when you apply it to all Encodable types.

Reading the code, it's not clear what `"string".typeErased()` will produce. This will be more clear.