### PR TITLE
Dynamic vs. static: making FoundationExtensions the static default

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,13 @@ let package = Package(
     name: "FoundationExtensions",
     platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
     products: [
-        .library(name: "FoundationExtensions", type: .dynamic, targets: ["FoundationExtensions"]),
-        .library(name: "FoundationExtensionsStatic", targets: ["FoundationExtensions"])
+        .library(name: "FoundationExtensions", targets: ["FoundationExtensions"]),
+        .library(name: "FoundationExtensionsDynamic", type: .dynamic, targets: ["FoundationExtensions"])
     ],
     dependencies: [],
     targets: [
         .target(name: "FoundationExtensions", dependencies: []),
+        .target(name: "FoundationExtensionsDynamic", dependencies: []),
         .testTarget(name: "FoundationExtensionsTests", dependencies: ["FoundationExtensions"])
     ]
 )

--- a/Sources/FoundationExtensionsDynamic
+++ b/Sources/FoundationExtensionsDynamic
@@ -1,0 +1,1 @@
+FoundationExtensions


### PR DESCRIPTION
Renamed startic / dynamic, make sure that packages without any suffix are static. This unifies
a inconsistency in a lot of framworks used in our products. Also, static linking is is an attempt to
fix this issue while deploying to TestFlight / AppStore:

ITMS-90334: Invalid Code Signature Identifier. The identifier "FoundationExtensions-5555494443d5626ab868338a93cce6b274e34595"
in your code signature for "FoundationExtensions" must match its Bundle Identifier "FoundationExtensions"

FoundationExtensions is the default now, the dynamic product is FoundationExtensionsDynamic.