### PR TITLE
`.eraseFailureToError()` Combine modifier.

### DIFF
--- a/Sources/FoundationExtensions/Combine/Publisher+EraseFailureToError.swift
+++ b/Sources/FoundationExtensions/Combine/Publisher+EraseFailureToError.swift
@@ -1,0 +1,21 @@
+#if canImport(Combine)
+import Combine
+import Foundation
+
+extension Publisher {
+    /// Erases `Failure` type to `Error`.
+    ///
+    ///     Just(1) // Just<Int>
+    ///         .eraseFailureToError() // Publishers.MapError<Just<Int>, Error>
+    ///
+    ///     Empty(outputType: Int.self,
+    ///           failureType: DecodingError.self) // Empty<Int, DecodingError>
+    ///     .eraseFailureToError() // Publishers.MapError<Empty<Int, DecodingError>, Error>
+    ///
+    /// - Returns: An ``Publishers.MapError`` wrapping this publisher.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public func eraseFailureToError() -> Publishers.MapError<Self, Error> {
+        mapError(identity)
+    }
+}
+#endif

--- a/Sources/FoundationExtensions/Promise/PromiseType+EraseFailureToError.swift
+++ b/Sources/FoundationExtensions/Promise/PromiseType+EraseFailureToError.swift
@@ -1,0 +1,19 @@
+// Copyright © 2023 Lautsprecher Teufel GmbH. All rights reserved.
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+extension PromiseType {
+    /// Erases `Failure` type to `Error`.
+    ///
+    ///     Publishers.Promise<Int, Never>(value: 1) // Publishers.Promise<Int, Never>
+    ///         .eraseFailureToError() // Publishers.Promise<Publishers.Promise<Int, Never>.Output, Error>
+    ///
+    /// - Returns: An ``Publishers.Promise`` wrapping this promise.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public func eraseFailureToError() -> Publishers.Promise<Output, Error> {
+        mapError(identity)
+    }
+}
+#endif


### PR DESCRIPTION
- Tests are not possible since it has compiler time validation (Methods returns `Error` instead of `Failure` type.).
- This is important and useful when we need to remove the `Failure` type, I needed it in several places during handler implementations. Also useful for API design.